### PR TITLE
add macos details, update details

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,18 +5,39 @@ Thank you for your interest in contributing! We welcome all contributions no mat
 their size. Please read along to learn how to get started. If you get stuck, feel free
 to ask for help in `Ethereum Python Discord server <https://discord.gg/GHryRvPB84>`_.
 
+Dependencies
+^^^^^^^^^^^^
+
+The following dependencies are needed to build py-libp2p:
+
+* `GNU Multiprecision Arithmetic Library <https://gmplib.org/>`_
+* `CMake <https://cmake.org>`
+* `freedesktop.org pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config>`
+
+On Debian Linux you can install them using the following command:
+
+.. code:: sh
+
+    sudo apt-get install cmake pkg-config libgmp-dev
+
+On MacOS, you can install them using the following command:
+
+.. code:: sh
+
+   brew install cmake pkgconfig gmp
+
 Setting the stage
 ~~~~~~~~~~~~~~~~~
 
-To get started, fork the repository to your own github account, then clone it to your
-development machine:
+To get started, fork the repository to your own github account, then clone it
+to your development machine:
 
 .. code:: sh
 
     git clone git@github.com:your-github-username/py-libp2p.git
 
-Next, install the development dependencies. We recommend using a virtual environment,
-such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
+Next, install the development dependencies. We recommend using a virtual
+environment, such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
 
 .. code:: sh
 
@@ -26,19 +47,22 @@ such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
     python -m pip install -e ".[dev]"
     pre-commit install
 
-
-Dependencies
-^^^^^^^^^^^^
-
-On Debian Linux you will need to ensure that you have the
-`GNU Multiprecision Arithmetic Library <https://gmplib.org/>`_
-installed since it is a dependency of the fastecdsa package. You can install it using
-the following command:
+An alternative to virtualenv is to use the built-in Python3 venv module:
 
 .. code:: sh
 
-    sudo apt-get install libgmp-dev
+   cd py-libp2p
+   python3 -m venv ./venv
+   . venv/bin/activate
+   python3 -m pip install -e ".[dev]"
+   pre-commit install
 
+Currently, on MacOS you must help the build command find and link against the
+gmp library. On MacOS run the following to build py-libp2p:
+
+.. code:: sh
+
+   CFLAGS="`pkg-config --cflags gmp`" LDFLAGS="`pkg-config --libs gmp`" python3 -m pip install -e ".[dev]"
 
 Requirements
 ^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>

## What was wrong?

Related to Issue #519

The [contributing](https://py-libp2p.readthedocs.io/en/latest/contributing.html) page didn't have any details on installing the correct dependencies before trying to build it.

Also, missing MacOS details.

## How was it fixed?

Added documentation.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://forum.ih8mud.com/attachments/12615197_10208942892997560_5925844486790812111_o-jpg.1221022/)
